### PR TITLE
Release merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,3 +67,12 @@ jobs:
     - name: Run tests
       run: |
         go test -failfast -v .
+
+  # We want to release all merges to main for now:
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    if: github.ref == 'refs/heads/main'
+    steps:
+    - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,11 +68,15 @@ jobs:
       run: |
         go test -failfast -v .
 
+    - name: Fail
+      run: |
+        exit 1
+
   # We want to release all merges to main for now:
   release:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,15 +68,15 @@ jobs:
       run: |
         go test -failfast -v .
 
-    - name: Fail
-      run: |
-        exit 1
-
   # We want to release all merges to main for now:
   release:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v2
+
+    - name: Release new version
+      run: |
+        echo y | ./scripts/bump_version.sh

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ archives:
       amd64: x86_64
     files:
       - none* # package only the binary
+    name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,6 @@ builds:
 archives:
   - replacements:
       amd64: x86_64
-      darwin: macOS
     files:
       - none* # package only the binary
     format_overrides:


### PR DESCRIPTION
This change will tag a new release after every successful build in main. This should trigger goreleaser to build all the dist files and copy them to the release

This also updates goreleaser settings to be more friendly to install scripts:
- removes the renaming of darwing to macOS, as it makes the install script more complicated.
- ensures the consistency between version tag and version in the file name