### PR TITLE
Remove install tools build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,6 @@ jobs:
       run: |
         ls ${{ github.workspace }}
 
-    - name: Install tools
-      run: make install-tools
-
     - name: Build
       run: go build .
 


### PR DESCRIPTION
This step should not be neded as bingo will autodownload required tools from the Makefile