### PR TITLE
Always run goreleaser after main builds

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - '*'
+  # Tags created by build workflow don't trigger ^, this ensures we still run goreleaser: 
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
It seems that tags created from a github action are not triggering the
goreleaser workflow. This change ensures that we run goreleaser after
building main