### PR TITLE
Add release notifications in slack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,9 +72,55 @@ jobs:
       run: |
         go test -failfast -v .
 
+  on-release-start:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 2
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Post start to Slack
+        uses: slackapi/slack-github-action@v1.17.0
+        with:
+          channel-id: '#cd-activity'
+          payload: |
+            {
+              "text": "Publication of Xata CLI by ${{ github.actor }} started",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":butterfly: *Publication of Xata CLI by ${{ github.actor }} started* :butterfly:"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*More info:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Commit URL:* ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                },
+                {
+                  "type": "divider"
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.slack_token }}
+
   # We want to release all merges to main for now:
   release:
-    needs: build
+    needs: on-release-start
     runs-on: ubuntu-latest
     timeout-minutes: 1
     if: github.ref == 'refs/heads/main'
@@ -89,3 +135,55 @@ jobs:
     - name: Release new version
       run: |
         echo y | ./scripts/bump_version.sh
+
+  # Tags created by build workflow don't trigger, call goreleaser:
+  publish-release:
+    needs: [build, release]
+    if: github.ref == 'refs/heads/main'
+    uses: xataio/cli/.github/workflows/goreleaser.yml@main
+
+  on-failure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.ref == 'refs/heads/main' && failure()
+    needs: [publish-release]
+    steps:
+      - name: Post failure to Slack
+        uses: slackapi/slack-github-action@v1.17.0
+        with:
+          channel-id: '#cd-activity'
+          payload: |
+            {
+              "text": "Publication of Xata CLI failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":red_circle: @here *Publication of Xata CLI failed when triggered by ${{ github.actor }}* :red_circle:"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*More info:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Commit URL:* ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                },
+                {
+                  "type": "divider"
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.slack_token }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,14 +1,11 @@
 name: goreleaser
 
 on:
-  push:
-    tags:
-      - '*'
-  # Tags created by build workflow don't trigger ^, this ensures we still run goreleaser: 
-  workflow_run:
-    workflows: [build]
-    types: [completed]
-    branches: [main]
+# To be enabled once we disable autorelease in build.yml
+#  push:
+#    tags:
+#      - '*'
+  workflow_call:
 
 permissions:
   contents: write


### PR DESCRIPTION
This also updates the workflow to explicitly call goreleaser instead of
reacting to the build