### PR TITLE
Catch errors when doing schema pull on init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -139,7 +139,10 @@ func InitCommand(c *cli.Context) error {
 	if pull {
 		// Pull existing schema
 		fmt.Println("Pulling database schema...")
-		PullCommand(c)
+		err = PullCommand(c)
+		if err != nil {
+			return fmt.Errorf("Error pulling schema: %w", err)
+		}
 	} else {
 		// Create a new schema file
 		toWrite := defaultSchema


### PR DESCRIPTION
We were not catching pulling errors when calling `init`, this change
ensures that we tell the user if there is an error.