### PR TITLE
Support -no-color in the print migrations

### DIFF
--- a/cmd/auth_e2e_test.go
+++ b/cmd/auth_e2e_test.go
@@ -173,23 +173,27 @@ func TestAuthLoginCommand(t *testing.T) {
 			err = c.Close()
 			require.NoError(t, err)
 			err = cmd.Wait()
-			exitCode := 0
-			if err != nil {
-				if exitError, ok := err.(*exec.ExitError); ok {
-					exitCode = exitError.ExitCode()
-				} else {
-					require.NoError(t, err)
-				}
-			}
-			require.Equal(t, test.exitCode, exitCode)
+			require.Equal(t, test.exitCode, exitCodeFromError(t, err))
 		})
 	}
 }
 
+func exitCodeFromError(t *testing.T, err error) int {
+	exitCode := 0
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		} else {
+			require.NoError(t, err)
+		}
+	}
+	return exitCode
+}
+
 func startCommand(t *testing.T, configDir string, binaryPath string, args ...string) (*expect.Console, *exec.Cmd) {
 	c, err := NewVT10XConsole(
-		expect.WithDefaultTimeout(5 * time.Second),
-		// expect.WithStdout(os.Stdout),
+		expect.WithDefaultTimeout(5*time.Second),
+		expect.WithStdout(os.Stdout),
 	)
 	require.NoError(t, err)
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -138,7 +138,7 @@ func DeployCommand(c *cli.Context) error {
 	}
 
 	fmt.Printf("Migration plan preview:\n\n")
-	PrintMigration(plan.Migration)
+	PrintMigration(plan.Migration, c.Bool("nocolor"))
 	fmt.Println()
 
 	var yes bool

--- a/cmd/init_e2e_test.go
+++ b/cmd/init_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Netflix/go-expect"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,18 +27,83 @@ func TestInit(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
-	c, cmd := startCommand(t, configDir, config.TestBinaryPath, "init", "--workspaceid", workspaceID)
-	defer c.Close()
+	tests := []struct {
+		name      string
+		args      []string
+		procedure func(t *testing.T, c *expect.Console)
+		exitCode  int
+	}{
+		{
+			name: "simple init",
+			args: []string{"init", "--workspaceid", workspaceID},
+			procedure: func(t *testing.T, c *expect.Console) {
+				_, err := c.ExpectString("New database name:")
+				require.NoError(t, err)
 
-	_, err := c.ExpectString("New database name:")
-	require.NoError(t, err)
+				_, err = c.SendLine("test")
+				require.NoError(t, err)
 
-	_, err = c.SendLine("test")
-	require.NoError(t, err)
+				_, err = c.ExpectString("Init done. Edit xata/schema.json to get started.")
+				require.NoError(t, err)
+			},
+			exitCode: 0,
+		},
+		{
+			name: "run xata deploy",
+			args: []string{"deploy"},
+			procedure: func(t *testing.T, c *expect.Console) {
+				_, err := c.ExpectString("Database [test/main] created")
+				require.NoError(t, err)
 
-	_, err = c.ExpectString("Init done. Edit xata/schema.json to get started.")
-	require.NoError(t, err)
+				_, err = c.ExpectString("Apply the above migration?")
+				require.NoError(t, err)
 
-	err = cmd.Wait()
-	require.NoError(t, err)
+				_, err = c.SendLine("Y")
+				require.NoError(t, err)
+
+				_, err = c.ExpectString("Done.")
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "second init asks for -f",
+			args: []string{"init", "--workspaceid", workspaceID},
+			procedure: func(t *testing.T, c *expect.Console) {
+				_, err := c.ExpectString("Directory `xata` already exists, so I am not overwriting it. Use -f if you are sure.")
+				require.NoError(t, err)
+			},
+			exitCode: 1,
+		},
+		{
+			name: "second init with -f, pull DB",
+			args: []string{"init", "--workspaceid", workspaceID, "-f"},
+			procedure: func(t *testing.T, c *expect.Console) {
+				_, err := c.ExpectString("Do you want to pull from an existing database?")
+				require.NoError(t, err)
+
+				_, err = c.SendLine("test")
+				require.NoError(t, err)
+
+				_, err = c.ExpectString("Pulling database schema...")
+				require.NoError(t, err)
+
+				_, err = c.ExpectString("Init done. Edit xata/schema.json to get started.")
+				require.NoError(t, err)
+			},
+			exitCode: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, cmd := startCommand(t, configDir, config.TestBinaryPath, test.args...)
+			defer c.Close()
+
+			test.procedure(t, c)
+
+			err := cmd.Wait()
+			require.Equal(t, test.exitCode, exitCodeFromError(t, err))
+		})
+	}
+
 }


### PR DESCRIPTION
This extends the support for -no-color and adds a few more
e2e tests for the init workflows.