### PR TITLE
Only report errors main branch errors on slack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     needs: [publish-release]
-    if: failure()
+    if: github.ref == 'refs/heads/main' && failure()
     steps:
       - name: Post failure to Slack
         uses: slackapi/slack-github-action@v1.17.0


### PR DESCRIPTION
Before this change any failing PR would report an error to slack