### PR TITLE
[Discuss] Add dump & load commands

### DIFF
--- a/cmd/sak_dump.go
+++ b/cmd/sak_dump.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/tidwall/pretty"
+	"github.com/urfave/cli/v2"
+	"github.com/xataio/cli/client"
+	"github.com/xataio/cli/client/spec"
+	"github.com/xataio/cli/config"
+)
+
+const dumpPageSize int = 10
+
+func dumpBranch(c *cli.Context) error {
+
+	branchUrl := c.String("branchUrl")
+	var workspace, dbname, branch string
+	if branchUrl != "" {
+		var err error
+		workspace, dbname, branch, err = parseBranchUrl(branchUrl)
+		if err != nil {
+			return fmt.Errorf("Invalid branch URL: %w", err)
+		}
+	} else {
+		fmt.Println("Branch URL not specified, trying to read from current directory.")
+		var err error
+		dbname, _, branch, err = getDBNameAndBranch(c)
+		if err != nil {
+			return err
+		}
+
+		workspace, err = getWorkspaceID(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	apiKey, err := config.APIKey(c)
+	if err != nil {
+		return err
+	}
+	client, err := client.NewXataClient(apiKey, workspace)
+	if err != nil {
+		return err
+	}
+	clientWithResponses := &spec.ClientWithResponses{ClientInterface: client}
+
+	dir := c.String("output")
+	if _, err := os.Stat(dir); err == nil || !os.IsNotExist(err) {
+		return fmt.Errorf("Output directory %s already exists", dir)
+	}
+
+	err = os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("Error creating output directory %s: %w", dir, err)
+	}
+
+	dbbranch := spec.DBBranchNameParam(fmt.Sprintf("%s:%s", dbname, branch))
+	resp, err := clientWithResponses.GetBranchDetailsWithResponse(c.Context, dbbranch)
+	if err != nil {
+		return err
+	}
+	err = checkBranchDetails(resp)
+	if err != nil {
+		return err
+	}
+
+	baseBranch := resp.JSON200
+	err = dumpSchemaFile(dir, baseBranch.Schema)
+	if err != nil {
+		return err
+	}
+
+	for _, table := range baseBranch.Schema.Tables {
+		err = dumpTableFile(clientWithResponses, dir,
+			fmt.Sprintf("%s:%s", dbname, branch), table)
+		if err != nil {
+			return fmt.Errorf("Error dumping table %s: %w", table.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func dumpSchemaFile(dir string, schema spec.Schema) error {
+	file, err := json.MarshalIndent(schema, "", " ")
+	if err != nil {
+		return err
+	}
+	file = pretty.Pretty(file)
+
+	err = ioutil.WriteFile(path.Join(dir, "schema.json"), file, 0644)
+	if err != nil {
+		return fmt.Errorf("writing schema file: %w", err)
+	}
+
+	fmt.Printf("Schema file written in: %s\n", path.Join(dir, "schema.json"))
+	return nil
+}
+
+func dumpTableFile(client *spec.ClientWithResponses, dir string, dbBranch string, table spec.Table) error {
+
+	fileName := fmt.Sprintf("%s.ndjson", table.Name)
+	outputFile, err := os.OpenFile(path.Join(dir, fileName), os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening file for writing: %w", err)
+	}
+
+	more := true
+	cursor := ""
+	pageSize := dumpPageSize
+	for more {
+		page := spec.PageConfig{
+			Size: &pageSize,
+		}
+		if cursor != "" {
+			page.After = &cursor
+		}
+		resp, err := client.QueryTableWithResponse(context.TODO(),
+			spec.DBBranchNameParam(dbBranch),
+			spec.TableNameParam(table.Name),
+			spec.QueryTableJSONRequestBody{
+				Page: &page,
+			})
+		if err != nil {
+			return fmt.Errorf("error quering: %w", err)
+		}
+		err = checkQueryDetails(resp)
+		if err != nil {
+			return err
+		}
+
+		for _, record := range resp.JSON200.Records {
+			recordMap := record.AdditionalProperties
+			if recordMap == nil {
+				recordMap = map[string]interface{}{}
+			}
+			recordMap["id"] = record.Id
+			recordMap["xata"] = record.Xata
+			recBytes, err := json.Marshal(recordMap)
+			if err != nil {
+				return err
+			}
+			_, err = outputFile.Write(recBytes)
+			if err != nil {
+				return err
+			}
+			_, err = outputFile.Write([]byte("\n"))
+			if err != nil {
+				return err
+			}
+		}
+
+		more = resp.JSON200.Meta.Page.More
+		cursor = resp.JSON200.Meta.Page.Cursor
+		if more {
+			fmt.Println("Continuing with", cursor)
+		} else {
+			fmt.Printf("Table %s dumped to %s\n", table.Name, fileName)
+		}
+	}
+	return nil
+}
+
+func checkQueryDetails(branch *spec.QueryTableResponse) error {
+	if branch.JSON401 != nil {
+		return ErrorUnauthorized{message: branch.JSON401.Message}
+	}
+	if branch.JSON400 != nil {
+		return fmt.Errorf(branch.JSON400.Message)
+	}
+	if branch.JSON404 != nil {
+		return fmt.Errorf(branch.JSON404.Message)
+	}
+
+	if branch.StatusCode() != http.StatusOK {
+		return fmt.Errorf("querying: %s", branch.Status())
+	}
+	if branch.JSON200 == nil {
+		return fmt.Errorf("querying: 200 OK unexpected response body")
+	}
+	return nil
+}
+
+func DumpBranchSubcommand() *cli.Command {
+	return &cli.Command{
+		Name:   "dump",
+		Usage:  "Dump the contents of a given database branch to a folder.",
+		Action: dumpBranch,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "output",
+				Usage:    "The output directory to write the dump to.",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "branchUrl",
+				Usage: "The URL of the branch to dump, in the form: https://{workspaceid}.xata.sh/db/{database}:{branch}",
+			},
+		},
+	}
+}

--- a/cmd/sak_load.go
+++ b/cmd/sak_load.go
@@ -1,0 +1,322 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/urfave/cli/v2"
+	"github.com/xataio/cli/client"
+	"github.com/xataio/cli/client/spec"
+	"github.com/xataio/cli/config"
+)
+
+func loadBranch(c *cli.Context) error {
+	branchUrl := c.String("branchUrl")
+	dir := c.String("input")
+	workspace, dbname, branch, err := parseBranchUrl(branchUrl)
+	if err != nil {
+		return fmt.Errorf("Invalid branch URL: %w", err)
+	}
+
+	apiKey, err := config.APIKey(c)
+	if err != nil {
+		return err
+	}
+	client, err := client.NewXataClient(apiKey, workspace)
+	if err != nil {
+		return err
+	}
+	cr := &spec.ClientWithResponses{ClientInterface: client}
+
+	assumeMigrationYes := false
+
+	// Make sure the destination branch exists
+	dbbranch := spec.DBBranchNameParam(fmt.Sprintf("%s:%s", dbname, branch))
+	resp, err := cr.GetBranchDetailsWithResponse(c.Context, dbbranch)
+	if err != nil {
+		return err
+	}
+	if resp.JSON404 != nil {
+		fmt.Printf("Branch [%s] does not exist. Creating it...\n", dbbranch)
+		assumeMigrationYes = true
+
+		err = ensureBranchExist(c.Context, client, dbname, branch)
+		if err != nil {
+			return fmt.Errorf("Error creating branch [%s]: %w", dbbranch, err)
+		}
+	} else {
+		err = checkBranchDetails(resp)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Migrate to the schema saved in the file
+	schemaFile := path.Join(dir, "schema.json")
+	schema, err := readSchemaFromFile(schemaFile)
+	if err != nil {
+		return err
+	}
+
+	err = migrateBranchToSchema(c, client, dbbranch, schema, assumeMigrationYes)
+	if err != nil {
+		return err
+	}
+
+	// Load the data
+	for _, table := range schema.Tables {
+		err = loadTableFile(c.Context, client, dir, dbbranch, table)
+		if err != nil {
+			return fmt.Errorf("Error loading table [%s]: %w", table.Name, err)
+		}
+	}
+	return nil
+}
+
+func loadTableFile(ctx context.Context, client *spec.Client, dir string,
+	dbbranch spec.DBBranchNameParam, table spec.Table) error {
+
+	tableFileName := path.Join(dir, table.Name+".ndjson")
+	tableFile, err := os.Open(tableFileName)
+	if err != nil {
+		return fmt.Errorf("opening table file [%s]: %w", tableFileName, err)
+	}
+	defer tableFile.Close()
+
+	scanner := bufio.NewScanner(tableFile)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo += 1
+		recBytes := scanner.Bytes()
+		var record map[string]interface{}
+		err := json.Unmarshal(recBytes, &record)
+		if err != nil {
+			return fmt.Errorf("parsing json at line %d: %w", lineNo, err)
+		}
+
+		idVal, ok := record["id"]
+		if !ok {
+			return fmt.Errorf("id record not found at line %d", lineNo)
+		}
+		recID, ok := idVal.(string)
+		if !ok {
+			return fmt.Errorf("id record should be string at line %d", lineNo)
+		}
+		delete(record, "id")
+		delete(record, "xata")
+
+		record, err = removeLinkValues(table.Columns, record)
+		if err != nil {
+			return fmt.Errorf("line %d: %w", lineNo, err)
+		}
+
+		// TODO: use bulk insert here once we support bulks with ID specified
+		resp, err := client.InsertRecordWithID(ctx, dbbranch,
+			spec.TableNameParam(table.Name),
+			spec.RecordIDParam(recID),
+			&spec.InsertRecordWithIDParams{}, record)
+		if err != nil {
+			return fmt.Errorf("inserting line %d: %w", lineNo, err)
+		}
+		if resp.StatusCode > 299 {
+			return fmt.Errorf("inserting line %d: %d %s", lineNo, resp.StatusCode, responseToError(resp))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning file: %w", err)
+	}
+	return nil
+}
+
+func removeLinkValues(columns []spec.Column, record map[string]interface{}) (map[string]interface{}, error) {
+	for _, col := range columns {
+		if col.Type == spec.ColumnTypeLink {
+			delete(record, col.Name)
+		}
+		if col.Type == spec.ColumnTypeObject {
+			subRecord, exists := record[col.Name]
+			if !exists {
+				continue
+			}
+			subRecordMap, ok := subRecord.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("unexpected non-object for key %s", col.Name)
+			}
+			var err error
+			record[col.Name], err = removeLinkValues(col.Columns, subRecordMap)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return record, nil
+}
+
+func readSchemaFromFile(schemaFile string) (spec.Schema, error) {
+	jsonFile, err := os.Open(schemaFile)
+	if err != nil {
+		return spec.Schema{}, fmt.Errorf("reading schema file [%s]: %w", schemaFile, err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return spec.Schema{}, fmt.Errorf("reading schema file [%s]: %w", schemaFile, err)
+	}
+
+	var schema spec.Schema
+	err = json.Unmarshal([]byte(byteValue), &schema)
+	if err != nil {
+		return spec.Schema{}, fmt.Errorf("parsing schema json file [%s]: %w", schemaFile, err)
+	}
+
+	return schema, nil
+}
+
+func migrateBranchToSchema(c *cli.Context, client *spec.Client,
+	dbbranch spec.DBBranchNameParam, schema spec.Schema, assumeYes bool) error {
+
+	cr := &spec.ClientWithResponses{ClientInterface: client}
+
+	respPlan, err := cr.GetBranchMigrationPlanWithResponse(c.Context,
+		dbbranch,
+		spec.GetBranchMigrationPlanJSONRequestBody(schema))
+	if err != nil {
+		return fmt.Errorf("Error getting migration plan: %w", err)
+	}
+	if err = checkBranchMigrationPlan(respPlan); err != nil {
+		return err
+	}
+
+	plan := respPlan.JSON200
+	if (plan.Migration.NewTables == nil || len(plan.Migration.NewTables.AdditionalProperties) == 0) &&
+		plan.Migration.RemovedTables == nil &&
+		plan.Migration.TableMigrations == nil {
+		fmt.Println("Schema is already up to date")
+		return nil
+	}
+
+	fmt.Printf("Apply a schema migration first. Migration plan preview:\n\n")
+	PrintMigration(plan.Migration, c.Bool("nocolor"))
+	fmt.Println()
+
+	if !assumeYes {
+		var yes bool
+		prompt := &survey.Confirm{
+			Message: "Apply the above migration?",
+			Default: true,
+		}
+		survey.AskOne(prompt, &yes)
+		if !yes {
+			return fmt.Errorf("Execution cancelled")
+		}
+	}
+
+	now := spec.DateTime(time.Now())
+	plan.Migration.CreatedAt = &now
+	mResp, err := cr.ExecuteBranchMigrationPlanWithResponse(c.Context,
+		dbbranch,
+		spec.ExecuteBranchMigrationPlanJSONRequestBody(*plan))
+	if err != nil {
+		return fmt.Errorf("Error executing migration: %w", err)
+	}
+	if mResp.StatusCode() > 299 {
+		return fmt.Errorf("Error executing migration: %s", mResp.Status())
+	}
+
+	fmt.Println("Schema migrated.")
+
+	return nil
+}
+
+// ensureBranchExist creates a branch if it does not exist. If the parent database doesn't
+// exist, it is created as well.
+func ensureBranchExist(ctx context.Context, client *spec.Client, dbname, branch string) error {
+	dbbranch := spec.DBBranchNameParam(fmt.Sprintf("%s:%s", dbname, branch))
+	clientWithResponses := &spec.ClientWithResponses{ClientInterface: client}
+
+	resp, err := clientWithResponses.GetBranchListWithResponse(ctx, spec.DBNameParam(dbname))
+	if err != nil {
+		return err
+	}
+	if resp.JSON404 != nil {
+		resp, err := client.CreateDatabase(ctx, spec.DBNameParam(dbname), spec.CreateDatabaseJSONRequestBody{
+			BranchName: &branch,
+		})
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode > 299 {
+			return responseToError(resp)
+		}
+		fmt.Printf("Created database [%s] with branch [%s]\n", dbname, branch)
+		return nil
+	}
+	if err = checkBranchesList(resp); err != nil {
+		return err
+	}
+
+	if len(resp.JSON200.Branches) == 0 {
+		return fmt.Errorf("Unexpected: no branches found in database [%s]", dbname)
+	}
+
+	response, err := client.CreateBranch(ctx, dbbranch, &spec.CreateBranchParams{}, spec.CreateBranchJSONRequestBody{
+		From: &resp.JSON200.Branches[0].Name,
+	})
+	if err != nil {
+		return err
+	}
+	if response.StatusCode > 299 {
+		return responseToError(response)
+	}
+	fmt.Printf("Created branch [%s]\n", dbbranch)
+	return nil
+}
+
+func checkBranchesList(resp *spec.GetBranchListResponse) error {
+	if resp.JSON401 != nil {
+		return ErrorUnauthorized{message: resp.JSON401.Message}
+	}
+	if resp.JSON400 != nil {
+		return fmt.Errorf(resp.JSON400.Message)
+	}
+	if resp.JSON404 != nil {
+		return fmt.Errorf(resp.JSON404.Message)
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("listing branches: %s", resp.Status())
+	}
+	if resp.JSON200 == nil {
+		return fmt.Errorf("listing branches: 200 OK unexpected response body")
+	}
+	return nil
+}
+
+func LoadBranchSubcommand() *cli.Command {
+	return &cli.Command{
+		Name:   "load",
+		Usage:  "Load the contents of a dump folder to a branch.",
+		Action: loadBranch,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "input",
+				Usage:    "The input directory containing the branch dump.",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "branchUrl",
+				Usage:    "The URL of the branch in which to load the data, in the form: https://{workspaceid}.xata.sh/db/{database}:{branch}",
+				Required: true,
+			},
+		},
+	}
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -202,6 +203,21 @@ func printResponse(c *cli.Context, resp *http.Response, err error) error {
 		}
 
 		fmt.Println(string(s))
+	}
+	return nil
+}
+
+func responseToError(resp *http.Response) error {
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode > 299 {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return ErrorUnauthorized{message: getMessage(bodyBytes)}
+		}
+		return fmt.Errorf("Error from server: status %d: %s", resp.StatusCode, getMessage(bodyBytes))
 	}
 	return nil
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBranchUrl(t *testing.T) {
+	tests := map[string]struct {
+		url        string
+		worksapce  string
+		dbname     string
+		branch     string
+		errMessage string
+	}{
+		"normal": {
+			url:       "https://demo-21321.xata.sh/db/test:main",
+			worksapce: "demo-21321",
+			dbname:    "test",
+			branch:    "main",
+		},
+		"special chars": {
+			url:       "https://demo-21321.xata.sh/db/test-as_dsa!sada:main_12321-1231231",
+			worksapce: "demo-21321",
+			dbname:    "test-as_dsa!sada",
+			branch:    "main_12321-1231231",
+		},
+		"missing workspace": {
+			url:        "https://xata.sh/db/test:main",
+			errMessage: "Expected URL hostname to be a single subdomain under xata.sh (Example demo-1234.xata.sh). Got: xata.sh",
+		},
+		"too many subdomains": {
+			url:        "https://more.demo-21321.xata.sh/db/test:main",
+			errMessage: "Expected URL hostname to be a single subdomain under xata.sh (Example demo-1234.xata.sh). Got: more.demo-21321.xata.sh",
+		},
+		"missing branch": {
+			url:        "https://demo-21321.xata.sh/db/test",
+			errMessage: "Expected URL path to be of the form /db/{database}:{branch}. Got: /db/test",
+		},
+		"too many colons": {
+			url:        "https://demo-21321.xata.sh/db/test:main:main",
+			errMessage: "Expected URL path to be of the form /db/{database}:{branch}. Got: /db/test:main:main",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			workspace, dbname, branch, err := parseBranchUrl(test.url)
+
+			if test.errMessage == "" {
+				require.NoError(t, err)
+				require.Equal(t, test.worksapce, workspace)
+				require.Equal(t, test.dbname, dbname)
+				require.Equal(t, test.branch, branch)
+			} else {
+				require.EqualError(t, err, test.errMessage)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -207,6 +207,13 @@ func main() {
 				},
 			},
 			{
+				Name:  "sak",
+				Usage: "Xata Swiss-Army-Knife. Commands in experimental state.",
+				Subcommands: []*cli.Command{
+					cmd.DumpBranchSubcommand(),
+				},
+			},
+			{
 				Name:   "version",
 				Usage:  "Build information",
 				Action: printVersion,

--- a/main.go
+++ b/main.go
@@ -211,6 +211,7 @@ func main() {
 				Usage: "Xata Swiss-Army-Knife. Commands in experimental state.",
 				Subcommands: []*cli.Command{
 					cmd.DumpBranchSubcommand(),
+					cmd.LoadBranchSubcommand(),
 				},
 			},
 			{


### PR DESCRIPTION
Opening this up for discussion. It adds `dump` and `load` commands that work at a branch level like this, so you can copy the data from one branch to another (potentially across DBs and workspaces).

Dump schema and all tables in a branch:

```
./xata sak dump --branchUrl='https://xata-uq2d57.xata.sh/db/docs:main' --output docsDump
```

The output folder looks like this:

```
├── docsDump
│   ├── schema.json
│   └── search.ndjson
```

i.e. there's a `schema.json` file and then and `ndjson` file for each table, containing the data.

To load the data in a different branch (potentially from a different DB, different workspace, from prod to staging, etc.):

```
xata sak load --input ./docsDump --branchUrl="https://test-0n62d7.xata.sh/db/docs_test:main"
```

This will:
 * create the DB if it doesn't exist
 * create the branch if it doesn't exist
 * migrate the schema to the one in the dump
 * load the data

This is in draft mode and open for discussion because the two commands are experimental at best. Here are the reasons:

* dumping doesn't use a transaction like `pg_dump` does, which means that the dump can be inconsistent. We need to discuss how we could do this at the API layer
* in order to preserve IDs, the load works record by record so it's quite inefficient. We'd need the bulk API to support load-ing IDs to fix this.
* the links are not loaded right now, but this could be done pretty easily with a two pass. If we want to support that more efficiently, we'd need again to discuss API improvements.

Despite the above, the tool is still useful to me and probably would be useful to users as well. So I was thinking of some options:

* we introduce the equivalent of feature flags to the CLI, perhaps enabled via a secret env var
* we group the experimental commands under a sub-command which we mark explicitly as experimental stuff. This is what's currently done, using `sak` (for "Swiss-Army-Knife"), with this help entry:

```
   sak          Xata Swiss-Army-Knife. Commands in experimental state.
```