### PR TITLE
[auth] Replace "Introduce" with "Enter"

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -64,7 +64,7 @@ func login(c *cli.Context) error {
 
 	var apiKey string
 	prompt := &survey.Password{
-		Message: "Introduce your API key:",
+		Message: "Enter your API key:",
 		Help:    "You can generate a new API key at https://app.xata.io. You can learn more about API keys on our documentation site: https://docs.xata.io/concepts/api-keys",
 	}
 	err = survey.AskOne(prompt, &apiKey)

--- a/cmd/auth_e2e_test.go
+++ b/cmd/auth_e2e_test.go
@@ -77,7 +77,7 @@ func TestAuthLoginCommand(t *testing.T) {
 		{
 			name: "try an invalid API key",
 			procedure: func(t *testing.T, c *expect.Console) {
-				_, err = c.ExpectString("Introduce your API key:")
+				_, err = c.ExpectString("Enter your API key:")
 				require.NoError(t, err)
 				time.Sleep(1 * time.Second)
 				_, err = c.SendLine("invalid_key")
@@ -96,7 +96,7 @@ func TestAuthLoginCommand(t *testing.T) {
 		{
 			name: "login with valid API key",
 			procedure: func(t *testing.T, c *expect.Console) {
-				_, err = c.ExpectString("Introduce your API key:")
+				_, err = c.ExpectString("Enter your API key:")
 				require.NoError(t, err)
 				time.Sleep(1 * time.Second)
 				_, err = c.SendLine(config.TestKey)
@@ -120,7 +120,7 @@ func TestAuthLoginCommand(t *testing.T) {
 				_, err = c.SendLine("y")
 				require.NoError(t, err)
 
-				_, err = c.ExpectString("Introduce your API key:")
+				_, err = c.ExpectString("Enter your API key:")
 				require.NoError(t, err)
 				time.Sleep(1 * time.Second)
 				_, err = c.SendLine(config.TestKey)
@@ -219,7 +219,7 @@ func loginWithKeyCommand(t *testing.T, config *TestConfig, configDir string) {
 	c, cmd := startCommand(t, configDir, config.TestBinaryPath, "auth", "login")
 	defer c.Close()
 
-	_, err := c.ExpectString("Introduce your API key:")
+	_, err := c.ExpectString("Enter your API key:")
 	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 	_, err = c.SendLine(config.TestKey)


### PR DESCRIPTION
I just started playing with the Xata CLI. As expected, one of the first commands I ran was `xata auth login`. The prompt for the API was a bit confusing to me:

> Introduce your API key

In particular, the "Introduce" seemed a little awkward to me. This PR proposes to replace it with "Enter". 

However, if there are good reasons to use "Introduce" or if I'm the only one facing this confusion, please feel free to close this PR without merging. 